### PR TITLE
Key become optional for del() method

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -88,11 +88,15 @@ class Request
      *
      * @return mixed|null → value or null
      */
-    public static function del($key)
+    public static function del($key = null)
     {
         parse_str(file_get_contents('php://input'), $_DEL);
+        
+        if (isset($_DEL[$key])) {
+            return $_DEL[$key];
+        }
 
-        return (isset($_DEL[$key])) ? $_DEL[$key] : null;
+        return (! $key && isset($_DEL)) ? $_DEL : null;
     }
 
     /**


### PR DESCRIPTION
Hello, I saw that for get, post and put methods, the $key argument is optional, and if it is not given, it returns an array. Why is not $key optional for del method ? I just returned $key optional.